### PR TITLE
fix: properly return `no duplicates found` when no duplicate files are detected

### DIFF
--- a/model.go
+++ b/model.go
@@ -22,17 +22,18 @@ type model struct {
 	toDelete     []string
 }
 
-var (
-	titleStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("227")).Bold(true)
+type scanCompleteMsg struct{}
 
+var (
+	fileStyle         = lipgloss.NewStyle().Foreground(lipgloss.Color("255"))
 	selectedFileStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("42")).Bold(true)
+	titleStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("227")).Bold(true)
 	deleteStyle       = lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true)
 	confirmStyle      = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("196")).Padding(1)
 	itemStyle         = lipgloss.NewStyle().PaddingLeft(2)
 	selectedStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("42")).Bold(true)
 	errorStyle        = lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true)
-
-	helpStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Italic(true)
+	helpStyle         = lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Italic(true)
 )
 
 func initialModel(resultsChan <-chan []string) model {
@@ -114,6 +115,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		}
 
+	case scanCompleteMsg:
+		m.scanning = false
+		return m, nil
+
 	case []string:
 		m.scanning = false
 		m.groups = append(m.groups, msg)
@@ -166,47 +171,53 @@ func (m model) View() string {
 
 	if m.scanning {
 		b.WriteString("🔍 Scanning for duplicates...\n")
-		b.WriteString(helpStyle.Render("(Press q to quit)\n"))
-		return b.String()
-	}
-
-	if len(m.groups) == 0 {
+	} else if len(m.groups) == 0 {
 		b.WriteString("🎉 No duplicates found!\n")
-		return b.String()
+	} else {
+		current := m.groups[m.currentGroup]
+		b.WriteString(fmt.Sprintf(" Group %d/%d (%d files)\n",
+			m.currentGroup+1, len(m.groups), len(current)))
+
+		for i, file := range current {
+			var line strings.Builder
+			if _, selected := m.selected[m.currentGroup][i]; selected {
+				line.WriteString(selectedFileStyle.Render("◉ "))
+			} else {
+				line.WriteString("◌ ")
+			}
+
+			if i == m.currentFile {
+				line.WriteString("➔ ")
+			} else {
+				line.WriteString("  ")
+			}
+
+			line.WriteString(fileStyle.Render(file))
+
+			if _, selected := m.selected[m.currentGroup][i]; selected {
+				line.WriteString(deleteStyle.Render(" (marked for deletion)"))
+			}
+
+			b.WriteString(line.String() + "\n")
+		}
 	}
 
-	current := m.groups[m.currentGroup]
-	b.WriteString(fmt.Sprintf(" Group %d/%d (%d files)\n",
-		m.currentGroup+1, len(m.groups), len(current)))
-
-	for i, file := range current {
-		var line strings.Builder
-
-		if _, selected := m.selected[m.currentGroup][i]; selected {
-			line.WriteString(selectedFileStyle.Render("◉ "))
+	helpText := ""
+	if !m.showConfirm {
+		if m.scanning {
+			helpText = helpStyle.Render("(Press q to quit)")
+		} else if len(m.groups) > 0 {
+			helpText = helpStyle.Render(
+				"↑/↓: Navigate files • ←/→: Switch groups • Space: Select • d: Delete selected • q: Quit",
+			)
 		} else {
-			line.WriteString("◌ ")
+			helpText = helpStyle.Render("(Press q to quit)")
 		}
-
-		if i == m.currentFile {
-			line.WriteString("➔ ")
-		} else {
-			line.WriteString("  ")
-		}
-
-		line.WriteString(selectedFileStyle.Render(file))
-
-		if _, selected := m.selected[m.currentGroup][i]; selected {
-			line.WriteString(deleteStyle.Render(" (marked for deletion)"))
-		}
-
-		b.WriteString(line.String() + "\n")
 	}
 
-	help := helpStyle.Render(
-		"↑/↓: Navigate files • ←/→: Switch groups • Space: Select • d: Delete selected • q: Quit",
-	)
-	b.WriteString("\n" + help)
+	if helpText != "" {
+		b.WriteString("\n\n" + helpText)
+	}
 
 	return b.String()
 }
@@ -251,10 +262,11 @@ func (m model) removeDeletedFile(path string) {
 
 func waitForResults(results <-chan []string) tea.Cmd {
 	return func() tea.Msg {
-		if group, ok := <-results; ok {
-			return group
+		group, ok := <-results
+		if !ok {
+			return scanCompleteMsg{}
 		}
-		return nil
+		return group
 	}
 }
 


### PR DESCRIPTION
in the current implementation, when the tool finds no duplicates, it keeps showing "scanning for duplicates", however, it should show the user directly that no duplicates are found, this PR addresses this issue.